### PR TITLE
Documenting names of `state_vars` variables; docstrings

### DIFF
--- a/insilicho/growth_model.py
+++ b/insilicho/growth_model.py
@@ -50,7 +50,7 @@ def state_vars(
     params: parameters.InputParameters,
     feed_fn: typing.Optional[FeedFunctionType] = None,
     temp_fn: typing.Optional[TempFunctionType] = None,
-) -> typing.Tuple[float]:
+):
     """Variables related to state (species and condition) but are not solved for in the
     ODE system.
 

--- a/insilicho/growth_model.py
+++ b/insilicho/growth_model.py
@@ -65,7 +65,7 @@ def state_vars(
             profile. Defaults to None.
 
     Raises:
-        IOError: Raised if `feed_fn` or `temp_fn` are not provided.
+        ValueError: Raised if `feed_fn` or `temp_fn` are not provided.
 
     Returns:
         typing.Tuple[float]: Returns a tuple of floats with variables, as outlined in
@@ -76,7 +76,7 @@ def state_vars(
     Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Coxygen, V, pH = state
 
     if not feed_fn or not temp_fn:
-        raise IOError("feed/temp model missing")
+        raise ValueError("feed/temp model missing")
 
     F = feed_fn(t)
     T = temp_fn(t)

--- a/insilicho/growth_model.py
+++ b/insilicho/growth_model.py
@@ -30,13 +30,47 @@ def exponential_dependence_around_optima(
     return np.exp(-((x - optima) ** 2.0) / spread**2.0)
 
 
+AUXILIARY_CONDITIONS = [
+    "F",
+    "T",
+    "mu",
+    "mu_d",
+    "q_glc",
+    "q_gln",
+    "q_lac",
+    "q_amm",
+    "q_mab",
+    "Osmolarity",
+]
+
+
 def state_vars(
-    t,
-    state,
+    t: float,
+    state: np.ndarray,
     params: parameters.InputParameters,
     feed_fn: typing.Optional[FeedFunctionType] = None,
     temp_fn: typing.Optional[TempFunctionType] = None,
-):
+) -> typing.Tuple[float]:
+    """Variables related to state (species and condition) but are not solved for in the
+    ODE system.
+
+    Args:
+        t (float): Time point to evaluate on.
+        state (np.ndarray): Current states (e.g. Xv, Cglc). Must follow order specified
+            in parameters.InitialConditions.
+        params (parameters.InputParameters): Parameters of GrowCHO model.
+        feed_fn (typing.Optional[FeedFunctionType], optional): Callable describing feed
+            profile. Defaults to None.
+        temp_fn (typing.Optional[TempFunctionType], optional): Callable describing temp
+            profile. Defaults to None.
+
+    Raises:
+        IOError: Raised if `feed_fn` or `temp_fn` are not provided.
+
+    Returns:
+        typing.Tuple[float]: Returns a tuple of floats with variables, as outlined in
+            growth_model.AUXILIARY_CONDITIONS.
+    """
 
     # state
     Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Coxygen, V, pH = state

--- a/insilicho/growth_model.py
+++ b/insilicho/growth_model.py
@@ -30,20 +30,6 @@ def exponential_dependence_around_optima(
     return np.exp(-((x - optima) ** 2.0) / spread**2.0)
 
 
-AUXILIARY_CONDITIONS = [
-    "F",
-    "T",
-    "mu",
-    "mu_d",
-    "q_glc",
-    "q_gln",
-    "q_lac",
-    "q_amm",
-    "q_mab",
-    "Osmolarity",
-]
-
-
 def state_vars(
     t: float,
     state: np.ndarray,
@@ -68,8 +54,17 @@ def state_vars(
         ValueError: Raised if `feed_fn` or `temp_fn` are not provided.
 
     Returns:
-        typing.Tuple[float]: Returns a tuple of floats with variables, as outlined in
-            growth_model.AUXILIARY_CONDITIONS.
+        typing.Tuple[float]: Returns a tuple of floats of the following variables:
+            - F
+            - T
+            - mu
+            - mu_d
+            - q_glc
+            - q_gln
+            - q_lac
+            - q_amm
+            - q_mab
+            - Osmolarity
     """
 
     # state

--- a/insilicho/run.py
+++ b/insilicho/run.py
@@ -21,12 +21,20 @@ class GrowCHO:
         """Class to simulate CHO growth.
 
         Args:
-            config (typing.Union[typing.Dict[str, typing.Any], str]): A path to yaml file or a dictionary with initial conditions and parameter values.
-            feed_fn (typing.Optional[growth_model.FeedFunctionType]): A callable describing time dependence of feed profile, expected units for feed rate are in L/h.
-            temp_fn (typing.Optional[growth_model.TempFunctionType]): A callable describing time dependence of temperature profile, expected units for temp are in degC.
-            random_seed (int, optional): random seed to control sampling events. Defaults to 0.
-            param_rel_stddev (float, optional): Relative std deviation while sampling parameter, assumes a normal distribution.. Defaults to 0.05.
-            solver_max_step_size (float, optional): Max step size for the odeint solver to take. Defaults to np.inf.
+            config (typing.Union[typing.Dict[str, typing.Any], str]): A path to yaml
+                file or a dictionary with initial conditions and parameter values.
+            feed_fn (typing.Optional[growth_model.FeedFunctionType]): A callable
+                describing time dependence of feed profile, expected units for feed rate
+                are in L/h.
+            temp_fn (typing.Optional[growth_model.TempFunctionType]): A callable
+                describing time dependence of temperature profile, expected units for
+                temp are in degC.
+            random_seed (int, optional): random seed to control sampling events.
+                Defaults to 0.
+            param_rel_stddev (float, optional): Relative std deviation while sampling
+                parameter, assumes a normal distribution.. Defaults to 0.05.
+            solver_max_step_size (float, optional): Max step size for the odeint solver
+                to take. Defaults to np.inf.
         """
         cfg_dict, cfg_path = None, None
         if type(config) == dict:
@@ -50,7 +58,8 @@ class GrowCHO:
         """Randomize parameters for the model.
 
         Args:
-            rel_stddev (float): Relative std deviation while sampling parameter, assumes a normal distribution.
+            rel_stddev (float): Relative std deviation while sampling parameter, assumes
+                a normal distribution.
         """
         float_params = {
             f.name: getattr(self.params, f.name)
@@ -73,16 +82,21 @@ class GrowCHO:
         """Execute the GrowCHO model object
 
         Args:
-            initial_conditions (typing.Optional[typing.Dict[str, typing.Any]], optional): Initial conditions for the solver. Defaults to conditions given in insilicho.parameters.
-            plot (bool, optional): option to plot data using matplotlib. Defaults to False.
-            sampling_stddev (float, optional): scale of error in normal distributed sampling event. Defaults to 0.05.
+            initial_conditions (typing.Optional[typing.Dict[str, typing.Any]],
+                optional): Initial conditions for the solver. Defaults to conditions
+                given in insilicho.parameters.
+            plot (bool, optional): option to plot data using matplotlib. Defaults to
+                False.
+            sampling_stddev (float, optional): scale of error in normal distributed
+                sampling event. Defaults to 0.05.
 
         Raises:
             IOError: If temp or feed callables were not supplied.
             RuntimeError: If integration/LSODA solver runs into failures.
 
         Returns:
-            typing.Dict[str, typing.Any]: Sampled metabolite, volume and cell concentrations.
+            typing.Dict[str, typing.Any]: Sampled metabolite, volume and cell
+                concentrations.
         """
 
         if initial_conditions:
@@ -170,11 +184,14 @@ def flex2_sampling(
     """Samples datapoints from a simulation output.
 
     Args:
-        state (np.ndarray): Array of state solutions (Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Coxygen, V, pH) for all points in tspan.
-        state_vars (np.ndarray): Array of state variable (F, T, mu, mu_d, q_glc, q_gln, q_lac, q_amm, q_mab, Osmolarity) solutions for all points in tspan.
+        state (np.ndarray): Array of state solutions (Xv, Xt, Cglc, Cgln, Clac, Camm,
+            Cmab, Coxygen, V, pH) for all points in tspan.
+        state_vars (np.ndarray): Array of state variable (F, T, mu, mu_d, q_glc, q_gln,
+            q_lac, q_amm, q_mab, Osmolarity) solutions for all points in tspan.
         params (parameters.InputParameters): Input parameters for simulation system.
         tspan (np.ndarray): time array (in hours) over which the system was solved.
-        sampling_stddev (float, optional): scale of error in normal distributed sampling event. Defaults to 0.05.
+        sampling_stddev (float, optional): scale of error in normal distributed sampling
+            event. Defaults to 0.05.
 
     Returns:
         typing.Dict[str, typing.Any]: Results from sampling i.e., Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Osmolarity and time.

--- a/insilicho/run.py
+++ b/insilicho/run.py
@@ -91,7 +91,7 @@ class GrowCHO:
                 sampling event. Defaults to 0.05.
 
         Raises:
-            IOError: If temp or feed callables were not supplied.
+            IOError: If initial conditions were not supplied.
             RuntimeError: If integration/LSODA solver runs into failures.
 
         Returns:

--- a/insilicho/solver.py
+++ b/insilicho/solver.py
@@ -19,12 +19,18 @@ def solve(
 
     Args:
         params (parameters.InputParameters): Parameters for the model.
-        initial_conditions (parameters.InitialConditions): Initial conditions for the solver.
-        model (growth_model.model, optional): Differential equations to solve. Defaults to growth_model.model.
-        tspan (List, optional): time array (in hrs) over which to solve the system. Defaults to np.linspace(0, 288, 10000).
-        feed_fn (growth_model.FeedFunctionType, optional): Callable describing feed profile. Defaults to None.
-        temp_fn (growth_model.TempFunctionType, optional): Callable describing temp profile. Defaults to None.
-        solver_hmax (float, optional): max step size solver can take. Defaults to np.inf.
+        initial_conditions (parameters.InitialConditions): Initial conditions for the
+            solver.
+        model (growth_model.model, optional): Differential equations to solve. Defaults
+            to growth_model.model.
+        tspan (List, optional): time array (in hrs) over which to solve the system.
+            Defaults to np.linspace(0, 288, 10000).
+        feed_fn (growth_model.FeedFunctionType, optional): Callable describing feed
+            profile. Defaults to None.
+        temp_fn (growth_model.TempFunctionType, optional): Callable describing temp
+            profile. Defaults to None.
+        solver_hmax (float, optional): max step size solver can take. Defaults to
+            np.inf.
 
     Returns:
         state_model: Array of state solutions for all points in tspan.

--- a/tests/test_growth_model.py
+++ b/tests/test_growth_model.py
@@ -25,5 +25,5 @@ class TestGrowthModel:
         )
 
     def test_missing_fns_raise_errors(self):
-        with pytest.raises(IOError):
+        with pytest.raises(ValueError):
             assert growth_model.state_vars(1, ([1] * 10), parameters.InputParameters)


### PR DESCRIPTION
Not a good solution, just a bandaid. Adding a list of AUXILIARY_CONDITIONS for referencing the names of variables returned by `state_vars`. This list will update over the evolution of `growth_model`.