### PR TITLE
Scale noise according to variable

### DIFF
--- a/insilicho/parameters.py
+++ b/insilicho/parameters.py
@@ -61,8 +61,8 @@ class InputParameters(UnitValidationMixin):
     q_lac_max: typing.Union[float, str] = 0.2e-9  # mmol/cell/hour
 
     # Yield parameters
-    Y_amm_gln: typing.Union[float, str] = 0.9  # -
-    Y_lac_glc: typing.Union[float, str] = 0.25  # -
+    Y_amm_gln: typing.Union[float, str] = 0.9  # dimensionless (mol amm/ mol gln)
+    Y_lac_glc: typing.Union[float, str] = 0.25  # dimensionless (mol lac/ mol glc)
 
     # Feed conditions
     Cglc_feed: typing.Union[float, str] = 150.0  # mmol/liter
@@ -89,6 +89,8 @@ class InputParameters(UnitValidationMixin):
             "q_glc_max": "mmol/hr",
             "q_gln_max": "mmol/hr",
             "q_lac_max": "mmol/hr",
+            "Y_amm_gln": "dimensionless",
+            "Y_lac_glc": "dimensionless",
             "Cglc_feed": "mmol/L",
             "Cgln_feed": "mmol/L",
         }

--- a/insilicho/parameters.py
+++ b/insilicho/parameters.py
@@ -61,8 +61,8 @@ class InputParameters(UnitValidationMixin):
     q_lac_max: typing.Union[float, str] = 0.2e-9  # mmol/cell/hour
 
     # Yield parameters
-    Y_amm_gln: float = 0.9  # -
-    Y_lac_glc: float = 0.25  # -
+    Y_amm_gln: typing.Union[float, str] = 0.9  # -
+    Y_lac_glc: typing.Union[float, str] = 0.25  # -
 
     # Feed conditions
     Cglc_feed: typing.Union[float, str] = 150.0  # mmol/liter

--- a/insilicho/run.py
+++ b/insilicho/run.py
@@ -8,6 +8,32 @@ import yaml
 from insilicho import growth_model, parameters, plotter, solver, util
 
 
+def add_relative_normal_noise(
+    a: typing.Union[np.ndarray, float, int], relative_std_dev: float
+) -> np.ndarray:
+    """_summary_
+
+    Args:
+        a (typing.Union[np.ndarray, float, int]): Original value(s) that will act as
+            means.
+        relative_std_dev (float): Relative standard deviation. The resulting noise
+            sample will be taken from a normal distribution of mean = 1, standard
+            deviation = `relative_std_dev`. The noise sample(s) will then be multiplied
+            to value(s) in `a`.
+
+    Returns:
+        np.ndarray: an array of values with added noise.
+    """
+    if isinstance(a, float) or isinstance(a, int):
+        array = np.array([a])
+    else:
+        array = a
+
+    return array * np.random.normal(
+        loc=1.0, scale=float(relative_std_dev), size=len(array)
+    )
+
+
 class GrowCHO:
     def __init__(
         self,
@@ -70,7 +96,7 @@ class GrowCHO:
             )
         }
         for pname, pval in float_params.items():
-            new_val = np.random.normal(loc=pval, scale=rel_stddev * pval)
+            new_val = add_relative_normal_noise(pval, rel_stddev)[0]
             setattr(self.params, pname, new_val)
 
     def execute(
@@ -88,7 +114,7 @@ class GrowCHO:
             plot (bool, optional): option to plot data using matplotlib. Defaults to
                 False.
             sampling_stddev (float, optional): scale of error in normal distributed
-                sampling event. Defaults to 0.05.
+                sampling event, relative to sample magnitude. Defaults to 0.05.
 
         Raises:
             IOError: If initial conditions were not supplied.
@@ -137,7 +163,7 @@ class GrowCHO:
             state_vars,
             self.params,
             tspan,
-            sampling_stddev=sampling_stddev,
+            sampling_rel_stddev=sampling_stddev,
         )
 
     @property
@@ -179,7 +205,7 @@ def flex2_sampling(
     state_vars: np.ndarray,
     params: parameters.InputParameters,
     tspan: np.ndarray,
-    sampling_stddev: float = 0.05,
+    sampling_rel_stddev: float = 0.05,
 ) -> typing.Dict[str, typing.Any]:
     """Samples datapoints from a simulation output.
 
@@ -190,11 +216,12 @@ def flex2_sampling(
             q_lac, q_amm, q_mab, Osmolarity) solutions for all points in tspan.
         params (parameters.InputParameters): Input parameters for simulation system.
         tspan (np.ndarray): time array (in hours) over which the system was solved.
-        sampling_stddev (float, optional): scale of error in normal distributed sampling
-            event. Defaults to 0.05.
+        sampling_rel_stddev (float, optional): scale of error in normal distributed
+            sampling event, relative to sample magnitude. Defaults to 0.05.
 
     Returns:
-        typing.Dict[str, typing.Any]: Results from sampling i.e., Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Osmolarity and time.
+        typing.Dict[str, typing.Any]: Results from sampling i.e., Xv, Xt, Cglc, Cgln,
+            Clac, Camm, Cmab, Osmolarity and time.
     """
 
     Xv, Xt, Cglc, Cgln, Clac, Camm, Cmab, Coxygen, V, pH = state.transpose()
@@ -228,9 +255,7 @@ def flex2_sampling(
             res[k] = var[idx].tolist()
         else:
             res[k] = np.maximum(
-                var[idx] * np.random.normal(
-                    loc=1.0, scale=float(sampling_stddev), size=len(idx)
-                ),
+                add_relative_normal_noise(var[idx], sampling_rel_stddev),
                 parameters.EPSILON,
             ).tolist()
 

--- a/insilicho/run.py
+++ b/insilicho/run.py
@@ -207,12 +207,12 @@ def flex2_sampling(
     # sample across small time range, add noise
     for k, var in res_map.items():
         var = np.maximum(var, parameters.EPSILON)
-        if k == "time":
+        if k in ["time", "V"]:
             res[k] = var[idx].tolist()
         else:
             res[k] = np.maximum(
-                np.random.normal(
-                    loc=var[idx], scale=float(sampling_stddev), size=len(idx)
+                var[idx] * np.random.normal(
+                    loc=1.0, scale=float(sampling_stddev), size=len(idx)
                 ),
                 parameters.EPSILON,
             ).tolist()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import pytest
+
+from insilicho import run
+
+
+CFG_DICT = {"parameters": {"K_lys": "0.05 1/h"}, "initial_conditions": {"V": 0.025}}
+
+
+@pytest.fixture
+def constant_feed():
+    def F(time):
+        return 0.003
+
+    def T(time):
+        return 36.4
+
+    return run.GrowCHO(
+        CFG_DICT,
+        feed_fn=F,
+        temp_fn=T,
+    )
+
+
+@pytest.fixture
+def bolus_feed():
+    def F(time, bolus_size=0.03, num_bolus=10, bolus_frequency=24):
+        def dirac(t):
+            # https://stackoverflow.com/questions/63230568/numerical-solution-to-a-differential-equation-containing-a-dirac-delta-function
+            def tentfunc(t):
+                return max(0, 1 - abs(t))
+
+            N = 10.0
+            return sum(
+                N * tentfunc(N * (t - (i + 1) * bolus_frequency))
+                for i in range(num_bolus)
+            )
+
+        return bolus_size * dirac(time)  # L/h
+
+    def T(time):
+        return 36.4
+
+    # bolus feed requires manual reduction in step size to capture all steps.
+    return run.GrowCHO(
+        CFG_DICT,
+        feed_fn=F,
+        temp_fn=T,
+        solver_max_step_size=0.1,
+    )

--- a/tests/test_insilicho_run.py
+++ b/tests/test_insilicho_run.py
@@ -1,0 +1,69 @@
+import copy
+import dataclasses
+import numpy as np
+import pytest
+
+from insilicho import run
+
+
+class TestInsilichoRun:
+    def test_normal_noise(self):
+        assert run.add_relative_normal_noise(2, 0.1)
+
+        assert isinstance(
+            run.add_relative_normal_noise(np.array([1, 1.5, 2]), 0.05),
+            np.ndarray,
+        )
+
+        with pytest.raises(ValueError):
+            run.add_relative_normal_noise(np.array([1, 1.5, 2]), -0.05)
+
+    def test_flex2_sampling(self, constant_feed: run.GrowCHO):
+        constant_feed.execute(plot=False)
+        result_without_noise = run.flex2_sampling(
+            constant_feed.full_result.state,
+            constant_feed.full_result.state_vars,
+            constant_feed.params,
+            np.linspace(
+                0, 24 * constant_feed.params.Ndays, 1000 * constant_feed.params.Ndays
+            ),
+            0.0,
+        )
+        result_with_noise = run.flex2_sampling(
+            constant_feed.full_result.state,
+            constant_feed.full_result.state_vars,
+            constant_feed.params,
+            np.linspace(
+                0, 24 * constant_feed.params.Ndays, 1000 * constant_feed.params.Ndays
+            ),
+            0.07,
+        )
+
+        allow_list = ["time", "V"]
+
+        for (k, v1), v2 in zip(
+            result_without_noise.items(), result_with_noise.values()
+        ):
+            if k in allow_list:
+                assert v1 == v2
+            else:
+                assert v1 != v2
+
+
+class TestGrowCHO:
+    def test_random_noise(self, constant_feed: run.GrowCHO):
+        grow_cho_copy = copy.deepcopy(constant_feed)
+        original_params = copy.copy(grow_cho_copy.params)
+
+        grow_cho_copy._randomize_params(0.05)
+        new_params = copy.copy(grow_cho_copy.params)
+
+        allow_list = ["Cglc_feed", "Cgln_feed", "Ndays", "Nsamples"]
+
+        for f, v1, v2 in zip(
+            dataclasses.fields(grow_cho_copy.params),
+            original_params.tolist(),
+            new_params.tolist(),
+        ):
+            if f.name not in allow_list:
+                assert v1 != v2

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -2,51 +2,6 @@ import pytest
 
 from insilicho import run
 
-CFG_DICT = {"parameters": {"K_lys": "0.05 1/h"}, "initial_conditions": {"V": 0.025}}
-
-
-@pytest.fixture
-def bolus_feed():
-    def F(time, bolus_size=0.03, num_bolus=10, bolus_frequency=24):
-        def dirac(t):
-            # https://stackoverflow.com/questions/63230568/numerical-solution-to-a-differential-equation-containing-a-dirac-delta-function
-            def tentfunc(t):
-                return max(0, 1 - abs(t))
-
-            N = 10.0
-            return sum(
-                N * tentfunc(N * (t - (i + 1) * bolus_frequency))
-                for i in range(num_bolus)
-            )
-
-        return bolus_size * dirac(time)  # L/h
-
-    def T(time):
-        return 36.4
-
-    # bolus feed requires manual reduction in step size to capture all steps.
-    return run.GrowCHO(
-        CFG_DICT,
-        feed_fn=F,
-        temp_fn=T,
-        solver_max_step_size=0.1,
-    )
-
-
-@pytest.fixture
-def constant_feed():
-    def F(time):
-        return 0.003
-
-    def T(time):
-        return 36.4
-
-    return run.GrowCHO(
-        CFG_DICT,
-        feed_fn=F,
-        temp_fn=T,
-    )
-
 
 class TestBolusFeed:
     def test_solver_with_bolus_feed(self, bolus_feed: run.GrowCHO):
@@ -55,13 +10,13 @@ class TestBolusFeed:
         assert bolus_feed.full_result.info["message"] == "Integration successful."
         # Ending concentrations
         assert (bolus_feed.full_result.state[-1, 0]) * 1e-9 == pytest.approx(
-            26.5, rel=0.005
+            26.1, rel=0.005
         )  # Xv
         assert (bolus_feed.full_result.state[-1, 1]) * 1e-9 == pytest.approx(
-            27.0, rel=0.005
+            26.7, rel=0.005
         )  # Xt
         assert (bolus_feed.full_result.state[-1, 2]) == pytest.approx(
-            34.266, rel=0.005
+            35.7, rel=0.005
         )  # CGlc
 
 
@@ -72,13 +27,13 @@ class TestConstantFeed:
         assert constant_feed.full_result.info["message"] == "Integration successful."
         # Ending concentrations
         assert (constant_feed.full_result.state[-1, 0]) * 1e-9 == pytest.approx(
-            60.9, rel=0.005
+            60.1, rel=0.005
         )  # Xv
         assert (constant_feed.full_result.state[-1, 1]) * 1e-9 == pytest.approx(
-            64.9, rel=0.005
+            63.9, rel=0.005
         )  # Xt
         assert (constant_feed.full_result.state[-1, 2]) == pytest.approx(
-            0.068, rel=0.005
+            0.069, rel=0.005
         )  # CGlc
 
     def test_example(self):


### PR DESCRIPTION
I noticed that with the new update to include V, pH, and Coxygen in GrowCHO.run output, the flex_sampling method adds noise to them "unequally", that is, because these 3 variables have very low absolute magnitudes, the stddev of 0.05 has a much larger impact on them as compared to actual flex2 variables. 2 things modified here:

- stddev of 0.05 is applied with a mean of 1, prior to being multiplied onto the variable. this way the noise is "scaled" depending on absolute magnitude of variable value. This way, low values won't appear more noisy compared to high values.
- Made volume variable `V` unaffected by noise, which is more in-line with how volume is tracked in most bioreactors.

Image below shows the "before" -- we have extremely noisy V, pH, and Coxygen
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/12990047/213824844-52df4142-98de-4a77-b85d-11cd31d810b3.png">
